### PR TITLE
Make braytech start up faster if you have a stored manifest

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,8 @@ import './Core.css';
 import './App.css';
 
 import './utils/i18n';
-import { Globals, isProfileRoute } from './utils/globals';
+import { isProfileRoute } from './utils/globals';
+
 import dexie from './utils/dexie';
 import GoogleAnalytics from './components/GoogleAnalytics';
 
@@ -38,24 +39,44 @@ import Credits from './views/Credits';
 import Tools from './views/Tools';
 import ClanBannerBuilder from './views/Tools/ClanBannerBuilder';
 
+import bungie from './utils/bungie';
+
+// Print timings of promises to console (and performance logger)
+// if we're running in development mode.
+async function timed(name, promise) {
+  if (process.env.NODE_ENV === 'development') console.time(name);
+  const result = await promise;
+  if (process.env.NODE_ENV === 'development') console.timeEnd(name);
+  return result;
+}
+
 class App extends React.Component {
   constructor(props) {
     super();
-
     this.state = {
       status: {
         code: false,
         detail: false
-      },
-      manifest: {
-        version: false,
-        settings: false
       }
     };
 
     this.manifest = {};
-    this.bungieSettings = {};
     this.currentLanguage = props.i18n.getCurrentLanguage();
+
+    // We do these as early as possible - we don't want to wait
+    // for the component to mount before starting the web
+    // requests
+    this.startupRequests = {
+      storedManifest: timed(
+        'storedManifest',
+        dexie
+          .table('manifest')
+          .toCollection()
+          .first()
+      ),
+      manifestIndex: timed('getManifestIndex', bungie.manifestIndex()),
+      bungieSettings: timed('getSettings', bungie.settings())
+    };
   }
 
   updateViewport = () => {
@@ -69,154 +90,47 @@ class App extends React.Component {
     });
   };
 
-  componentDidUpdate() {
-    
-  }
-
-  getVersionAndSettings = () => {
-    let state = this.state;
-    state.status.code = 'checkManifest';
-    this.setState(state);
-
-    const paths = [
-      {
-        name: 'manifest',
-        url: 'https://www.bungie.net/Platform/Destiny2/Manifest/'
-      },
-      {
-        name: 'settings',
-        url: 'https://www.bungie.net/Platform/Settings/'
-      }
-    ];
-
-    let requests = paths.map(path => {
-      return fetch(path.url, {
-        headers: {
-          'X-API-Key': Globals.key.bungie
-        }
-      })
-        .then(response => {
-          return response.json();
-        })
-        .then(response => {
-          if (response.ErrorCode === 1) {
-            let object = {};
-            object[path.name] = response.Response;
-            return object;
-          }
-        });
-    });
-
-    return Promise.all(requests)
-      .then(responses => {
-        const response = assign(...responses);
-
-        this.bungieSettings = response.settings;
-
-        let availableLanguages = [];
-        for (var i in response.manifest.jsonWorldContentPaths) {
-          availableLanguages.push(i);
-        }
-
-        this.availableLanguages = availableLanguages;
-
-        return response.manifest.jsonWorldContentPaths[this.currentLanguage];
-      })
-      .catch(error => {
-        return error;
-      });
-  };
-
-  getManifest = version => {
-    let state = this.state;
-    state.status.code = 'fetchManifest';
-    state.manifest.version = version;
-    this.setState(state);
-
-    let manifest = async () => {
-      const request = await fetch(`https://www.bungie.net${version}`);
-      const response = await request.json();
-      return response;
-    };
-
-    manifest()
-      .then(manifest => {
-        let state = this.state;
-        state.status.code = 'setManifest';
-        this.setState(state);
-        dexie
-          .table('manifest')
-          .clear()
-          .then(() => {
-            dexie.table('manifest').add({
-              version: version,
-              value: manifest
-            });
-          })
-          .then(() => {
-            dexie
-              .table('manifest')
-              .toArray()
-              .then(manifest => {
-                this.manifest = manifest[0].value;
-                this.manifest.settings = this.bungieSettings;
-                let state = this.state;
-                state.status.code = 'ready';
-                this.setState(state);
-              });
-          });
-      })
-      .catch(error => {
-        console.log(error);
-      });
-  };
-
-  componentDidMount() {
+  async componentDidMount() {
     this.updateViewport();
     window.addEventListener('resize', this.updateViewport);
 
-    dexie
-      .table('manifest')
-      .toArray()
-      .then(manifest => {
-        if (manifest.length > 0) {
-          let state = this.state;
-          state.manifest.version = manifest[0].version;
-          this.setState(state);
-        }
-      })
-      .then(() => {
-        this.getVersionAndSettings()
-          .then(version => {
-            if (version !== this.state.manifest.version) {
-              this.getManifest(version);
-            } else {
-              dexie
-                .table('manifest')
-                .toArray()
-                .then(manifest => {
-                  if (manifest.length > 0) {
-                    this.manifest = manifest[0].value;
-                    this.manifest.settings = this.bungieSettings;
-                    let state = this.state;
-                    state.status.code = 'ready';
-                    this.setState(state);
-                  } else {
-                    let state = this.state;
-                    state.status.code = 'error';
-                    state.status.detail = 'Failure to access IndexedDB manifest';
-                    this.setState(state);
-                  }
-                });
-            }
-          })
-          .catch(error => {
-            let state = this.state;
-            state.status.code = 'error';
-            state.status.detail = error;
-            this.setState(state);
-          });
-      });
+    try {
+      await timed('setUpManifest', this.setUpManifest());
+    } catch (error) {
+      console.log(error);
+      this.setState({ status: { code: 'error', detail: error } });
+    }
+  }
+
+  async setUpManifest() {
+    this.setState({ status: { code: 'checkManifest' } });
+    const storedManifest = await this.startupRequests.storedManifest;
+    const manifestIndex = await this.startupRequests.manifestIndex;
+
+    const currentVersion = manifestIndex.jsonWorldContentPaths[this.currentLanguage];
+
+    if (!storedManifest || currentVersion !== storedManifest.version) {
+      // Manifest missing from IndexedDB or doesn't match the current version -
+      // download a new one and store it.
+      this.manifest = await this.downloadNewManifest(currentVersion);
+    } else {
+      this.manifest = storedManifest.value;
+    }
+
+    this.manifest.settings = await this.startupRequests.bungieSettings;
+    this.availableLanguages = Object.keys(manifestIndex.jsonWorldContentPaths);
+
+    this.setState({ status: { code: 'ready' } });
+  }
+
+  async downloadNewManifest(version) {
+    this.setState({ status: { code: 'fetchManifest' } });
+    const manifest = await timed('downloadManifest', bungie.manifest(version));
+
+    this.setState({ status: { code: 'setManifest' } });
+    await timed('clearTable', dexie.table('manifest').clear());
+    await timed('storeManifest', dexie.table('manifest').add({ version: version, value: manifest }));
+    return manifest;
   }
 
   componentWillUnmount() {
@@ -227,8 +141,6 @@ class App extends React.Component {
     if (!window.ga) {
       GoogleAnalytics.init();
     }
-
-    // console.log(this.props)
 
     if (this.state.status.code !== 'ready') {
       return <Loading state={this.state.status} theme={this.props.theme.selected} />;
@@ -417,8 +329,6 @@ function mapStateToProps(state, ownProps) {
 }
 
 export default compose(
-  connect(
-    mapStateToProps
-  ),
+  connect(mapStateToProps),
   withNamespaces()
 )(App);

--- a/src/utils/bungie.js
+++ b/src/utils/bungie.js
@@ -1,0 +1,32 @@
+// Bungie API access convenience methods
+import { Globals } from './globals';
+
+async function apiRequest(path) {
+  const options = { headers: { 'X-API-Key': Globals.key.bungie } };
+
+  const request = await fetch(`https://www.bungie.net${path}`, options).then(r => r.json());
+
+  if (request.ErrorCode !== 1) {
+    throw `Error retrieving ${path} from Bungie`;
+  }
+
+  return request.Response;
+}
+
+async function manifestIndex() {
+  return apiRequest('/Platform/Destiny2/Manifest/');
+}
+
+async function settings() {
+  return apiRequest('/Platform/Settings/');
+}
+
+async function manifest(version) {
+  return fetch(`https://www.bungie.net${version}`).then(a => a.json());
+}
+
+export default {
+  manifestIndex,
+  settings,
+  manifest
+};


### PR DESCRIPTION
I was going to look at the clan page performance, but noticed this first - every time I refreshed braytech it spent good 2-3 seconds locking down the CPU.

Before (timings are from when the refresh begins to when the loading spinner is gone):

![image](https://user-images.githubusercontent.com/97317/51289799-b6a01e80-1a55-11e9-8e67-4ec12d4bc4b1.png)

After:

![image](https://user-images.githubusercontent.com/97317/51289858-01219b00-1a56-11e9-81d8-4dbccd3b2875.png)

From the commit:

Rewrite logic that gets the non-character dependent stuff from Bungie
(manifest, manifest index, and settings) to use consistent async/await
logic, and add a convenience method to time these actions.

This has the side-effect of speeding up boot: as we make the requests
as early as possible, and as we're no longer pulling down 65mb of JSON
from IndexedDB twice when we don't need to, this takes the boot time on my
MBP from 3 seconds to 1.5 seconds.