### PR TITLE
Reducer cleanup

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,6 @@ import { isProfileRoute, themeOverride } from './utils/globals';
 import dexie from './utils/dexie';
 import * as bungie from './utils/bungie';
 import GoogleAnalytics from './components/GoogleAnalytics';
-import getMember from './utils/getMember';
 import store from './utils/reduxStore';
 import manifest from './utils/manifest';
 import * as ls from './utils/localStorage';
@@ -24,19 +23,11 @@ import Header from './components/Header';
 import Tooltip from './components/Tooltip';
 import Footer from './components/Footer';
 import NotificationApp from './components/NotificationApp';
-import NotificationProgress from './components/NotificationProgress';
-import RefreshService from './components/RefreshService';
+
 import ProfileRoutes from './ProfileRoutes';
 
 import Index from './views/Index';
 import CharacterSelect from './views/CharacterSelect';
-import Clan from './views/Clan';
-import Collections from './views/Collections';
-import Triumphs from './views/Triumphs';
-import Checklists from './views/Checklists';
-import Account from './views/Account';
-// import Character from './views/Character';
-import ThisWeek from './views/ThisWeek';
 import Vendors from './views/Vendors';
 import Inspect from './views/Inspect';
 import Read from './views/Read';

--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,7 @@ import GoogleAnalytics from './components/GoogleAnalytics';
 import getMember from './utils/getMember';
 import store from './utils/reduxStore';
 import manifest from './utils/manifest';
+import * as ls from './utils/localStorage';
 
 import Loading from './components/Loading';
 import Header from './components/Header';
@@ -84,11 +85,12 @@ class App extends React.Component {
       bungieSettings: timed('getSettings', bungie.settings())
     };
 
-    // const member = props.member;
+    const profile = ls.get('setting.profile');
 
-    // if (member && member.membershipId && member.membershipType) {
-    //   this.startupRequests.member = timed('getMember', getMember(member.membershipType, member.membershipId));
-    // }
+    store.dispatch({
+      type: 'MEMBER_SET_BY_PROFILE_ROUTE',
+      payload: profile
+    });
   }
 
   updateViewport = () => {
@@ -127,21 +129,6 @@ class App extends React.Component {
 
     tmpManifest.settings = await this.startupRequests.bungieSettings;
     this.availableLanguages = Object.keys(manifestIndex.jsonWorldContentPaths);
-
-    // if (this.startupRequests.member) {
-    //   try {
-    //     this.setState({ status: { code: 'fetchProfile' } });
-    //     const data = await this.startupRequests.member;
-    //     store.dispatch({
-    //       type: 'MEMBER_LOADED',
-    //       payload: data
-    //     });
-    //   } catch (error) {
-    //     // Ignore it if we can't load the member on app boot - the user will just
-    //     // need to select a new member
-    //     console.log(error);
-    //   }
-    // }
 
     manifest.set(tmpManifest);
 

--- a/src/ProfileRoutes.js
+++ b/src/ProfileRoutes.js
@@ -15,19 +15,12 @@ import Spinner from './components/Spinner';
 
 class ProfileRoutes extends React.Component {
   componentDidMount() {
-    const { member, match } = this.props;
-    const { membershipId, membershipType, characterId } = match.params;
+    const { membershipId, membershipType, characterId } = this.props.match.params;
 
-    if ((!member.data && !member.loading) || member.membershipId !== membershipId || member.membershipType !== parseInt(membershipType, 10)) {
-      store.dispatch({
-        type: 'MEMBER_LOAD_NEW_MEMBERSHIP',
-        payload: { membershipId, membershipType }
-      });
-    }
-
-    if (member.characterId !== characterId) {
-      store.dispatch({ type: 'MEMBER_CHARACTER_SELECT', payload: { membershipType, membershipId, characterId } });
-    }
+    store.dispatch({
+      type: 'MEMBER_SET_BY_PROFILE_ROUTE',
+      payload: { membershipType, membershipId, characterId }
+    });
   }
 
   render() {

--- a/src/utils/reducers/member.js
+++ b/src/utils/reducers/member.js
@@ -45,7 +45,10 @@ async function loadMember(membershipType, membershipId, characterId) {
 
 export default function memberReducer(state = defaultState, action) {
   if (!action.payload) return state;
-  const { membershipType, membershipId, characterId, data, error } = action.payload;
+  const { membershipId, characterId, data, error } = action.payload;
+
+  // Sometimes a number - let's just make it a string all the time
+  const membershipType = action.payload.membershipType && action.payload.membershipType.toString();
 
   if (action.type === 'MEMBER_SET_BY_PROFILE_ROUTE') {
     const membershipLoadNeeded = (!state.data && !state.loading) || state.membershipId !== membershipId || state.membershipType !== membershipType;
@@ -87,10 +90,7 @@ export default function memberReducer(state = defaultState, action) {
         error
       };
     case 'MEMBER_LOADED':
-      if (state.prevData !== data) {
-        data.updated = new Date().getTime();
-      }
-      // console.log(state.characterId, data.profile.characters.data[0].characterId);
+      if (state.prevData !== data) data.updated = new Date().getTime();
       return {
         ...state,
         characterId,

--- a/src/views/CharacterSelect/index.js
+++ b/src/views/CharacterSelect/index.js
@@ -22,13 +22,13 @@ class CharacterSelect extends React.Component {
   characterClick = characterId => {
     const { membershipType, membershipId } = this.props.member;
 
-    // ls.set('setting.profile', { membershipType, membershipId, characterId });
+    ls.set('setting.profile', { membershipType, membershipId, characterId });
   };
 
   profileClick = async (membershipType, membershipId, displayName) => {
     window.scrollTo(0, 0);
 
-    store.dispatch({ type: 'MEMBER_LOAD_NEW_MEMBERSHIP', payload: { membershipType, membershipId } });
+    store.dispatch({ type: 'MEMBER_LOAD_MEMBERSHIP', payload: { membershipType, membershipId } });
 
     if (displayName) {
       ls.update('history.profiles', { membershipType, membershipId, displayName }, true, 6);


### PR DESCRIPTION
Moves most of the member load logic into the main reducer and re-enables profile setting and the pre-load.

*seems* to work.