### PR TITLE
Deprecate Unused Translations

### DIFF
--- a/scripts/extractTranslations2.js
+++ b/scripts/extractTranslations2.js
@@ -104,8 +104,8 @@ const FilesLogic = {
         const result = [];
         Object.keys(translatedStrings).forEach(rawKey => {
             const key = unplaceholdify(rawKey);
-            if (rawKey === key)
-                return;
+            // Add this line to retain unused translations
+            // if (rawKey === key) return;
             if (!sourceStrings.has(key)) {
                 delete translatedStrings[rawKey];
                 result.push(key);
@@ -239,7 +239,7 @@ const NodesLogic = {
             await FilesLogic.write(jsonFile, JSON.stringify(translatedStrings, null, 2), { encoding: 'utf-8' });
             if (ARG_STATS) {
                 const { translated, notTranslated } = FilesLogic.countStrings(translatedStrings);
-                result[locale] = {
+                result[locale.toLocaleLowerCase()] = {
                     translated,
                     notTranslated,
                     added: addResult,

--- a/scripts/extractTranslations2.ts
+++ b/scripts/extractTranslations2.ts
@@ -85,6 +85,8 @@ const FilesLogic = {
         }
       });
     } catch (e) {
+      console.log(e);
+      console.log('>> ' + filename + ' <<');
       console.error('ScrapeStrings Failed: ' + e.message);
     }
   },
@@ -126,7 +128,8 @@ const FilesLogic = {
     const result: string[] = [];
     Object.keys(translatedStrings).forEach(rawKey => {
       const key = unplaceholdify(rawKey);
-      if (rawKey === key) return;
+      // Add this line to retain unused translations
+      // if (rawKey === key) return;
       if (!sourceStrings.has(key)) {
         delete translatedStrings[rawKey];
         result.push(key);
@@ -167,7 +170,7 @@ const NodesLogic = {
   getArgumentText(node: ASTNode): SourceStrings | false {
     const { arguments: args = [] } = node;
     if (args.length !== 1) {
-      throw new Error(`Argument count was not 1. Found: ${args.length}`);
+      //throw new Error(`Argument count was not 1. Found: ${args.length}`);
     }
     const arg = args[0];
     const storage: SourceStrings = new Set();
@@ -261,7 +264,7 @@ const NodesLogic = {
 
       if (ARG_STATS) {
         const { translated, notTranslated } = FilesLogic.countStrings(translatedStrings);
-        result[locale] = {
+        result[locale.toLocaleLowerCase()] = {
           translated,
           notTranslated,
           added: addResult,


### PR DESCRIPTION
Altered the translation extractor script to delete any unused translations from the `translation.json` files. 
Due to the nature of the script this will be done based on the translations used in code.