### PR TITLE
Fix crash when hovering over a vendor that doesn't have an associated bubble

### DIFF
--- a/src/components/Tooltip/Vendor/index.js
+++ b/src/components/Tooltip/Vendor/index.js
@@ -53,7 +53,7 @@ class Vendor extends React.Component {
       const largeIcon = definitionVendor.displayProperties && definitionVendor.displayProperties.largeIcon;
 
       const locations = definitionVendor.locations && definitionVendor.locations.length && definitionVendor.locations;
-      
+
       const definitionDestination = locations.length > 1 ? manifest.DestinyDestinationDefinition[definitionVendor.locations[1].destinationHash] : definitionVendor.locations.length && definitionVendor.locations[0].destinationHash && manifest.DestinyDestinationDefinition[definitionVendor.locations[0].destinationHash];
 
       const destination = definitionDestination && Object.values(destinations).find(d => d.destination.hash === definitionDestination.hash);
@@ -69,7 +69,7 @@ class Vendor extends React.Component {
       const extras = nodes && nodes.find(d => d.vendorHash === definitionVendor.hash);
       const screenshot = extras && extras.screenshot;
 
-      console.log(definitionVendor.hash, definitionBubble.hash)
+      console.log(definitionVendor.hash, (definitionBubble && definitionBubble.hash) || 'No bubble')
 
       return (
         <>


### PR DESCRIPTION
This PR fixes a crash which occurs when hovering over a vendor that does not have an associated bubble.

![braytech-vendor-hover-crash](https://user-images.githubusercontent.com/17512262/65413950-c1158200-de46-11e9-9eaf-c32cc24a1058.gif)

When hovering over a vendor in the Pursuits page, the vendor and bubble hashes are logged to the console. However, it is possible for a vendor to not have an associated bubble which causes an exception to be thrown.