### PR TITLE
Justify collection items correctly

### DIFF
--- a/src/components/PresentationNode.css
+++ b/src/components/PresentationNode.css
@@ -55,7 +55,7 @@
 .presentation-node .list.primary li {
   height: 72px;
   margin: 0 3px 3px 0;
-  flex-basis: calc(100% / 3 - 1px);
+  flex: 1;
 }
 
 .presentation-node .list.primary li:last-child {


### PR DESCRIPTION
Before:

<img width="336" alt="image" src="https://user-images.githubusercontent.com/858295/67577121-dfa0be80-f70d-11e9-9206-9cd7d9c23f74.png">


After:

<img width="334" alt="image" src="https://user-images.githubusercontent.com/858295/67577154-ecbdad80-f70d-11e9-9e48-dd15c80f4266.png">

And the rest of cases work as expected:

<img width="338" alt="image" src="https://user-images.githubusercontent.com/858295/67577181-fcd58d00-f70d-11e9-80bd-f82c905495ff.png">
