### PR TITLE
Link 'Lunar Rover' triumph to associated badge

### DIFF
--- a/src/utils/destinyEnums.js
+++ b/src/utils/destinyEnums.js
@@ -274,7 +274,11 @@ export const associationsCollectionsBadges = [
     badgeHash: 2759158924
   },
   {
-    recordHash: 3737200951, // Scared Duty (Raid)
+    recordHash: 96478725, // Lunar Rover
+    badgeHash: 2388540594
+  },
+  {
+    recordHash: 3737200951, // Sacred Duty (Raid)
     badgeHash: 223465203
   },
   {


### PR DESCRIPTION
This PR links the **Lunar Rover** triumph which is required for the **Shadowkeep** seal (**Harbinger** title) to the associated badge.