### PR TITLE
Disambiguation for DC Curse Cycle module in This Week

### DIFF
--- a/src/components/UserModules/DreamingCityCurseCycle/index.js
+++ b/src/components/UserModules/DreamingCityCurseCycle/index.js
@@ -26,7 +26,7 @@ class DreamingCityCurseCycle extends React.Component {
     return (
       <div className='user-module dreaming-city-curse-cycle'>
         <div className='sub-header'>
-          <div>{t("Savathûn's Curse")}</div>
+          <div>{t("Savathûn's Curse Cycle")}</div>
         </div>
         <h3>{rotation[cycleInfo.week.curse].strength}</h3>
         <div className='text'>

--- a/src/views/ThisWeek/Customise/index.js
+++ b/src/views/ThisWeek/Customise/index.js
@@ -439,7 +439,7 @@ class Customise extends React.Component {
       description: manifest.DestinyActivityDefinition[1893059148]?.displayProperties.description
     },
     DreamingCityCurseCycle: {
-      name: `${manifest.DestinyPresentationNodeDefinition[2516503814]?.displayProperties.name}: ${this.props.t("Savathûn's Curse")}`,
+      name: `${manifest.DestinyPresentationNodeDefinition[2516503814]?.displayProperties.name}: ${this.props.t("Savathûn's Curse Cycle")}`,
       description: manifest.DestinyActivityDefinition[1893059148]?.displayProperties.description
     },
     DreamingCityShatteredThrone: {


### PR DESCRIPTION
There are two modules in "This Week" called `Savathûn's Curse`.  This change adds the word "cycle" to the brief version that only indicates the curse strength.